### PR TITLE
Wrap sudo for compatibility with docker images

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The Ubuntu Mirror Selection Script is a Bash script designed to help you find an
 
 ## Prerequisites
 
-- This script works on Ubuntu systems.
+- This script works on Ubuntu systems. Requires `wget` and `bc`.
 - Ensure you have the necessary permissions to run the script, especially if you intend to modify system files.
 - For Ubuntu 24.04+, this script will modify the `ubuntu.sources` file in `/etc/apt/sources.list.d/`.
 - For older Ubuntu versions, this script will modify the traditional `/etc/apt/sources.list` file.
@@ -79,6 +79,8 @@ To use the script, follow these steps:
    ```
 
    This command retrieves mirrors from the United States (US), Japan (JP), and Indonesia (ID).
+
+   To automatically fill in the region based on your IP you can use `./run.sh -c $(curl -s https://ipinfo.io/json | jq -r '.country')` (requires `jq` to be installed).
 
 3. **Automatic Selection**: To automatically select the fastest mirror without user prompt and backup the sources files, you can use the `-a` or `--auto` option:
 

--- a/run.sh
+++ b/run.sh
@@ -332,6 +332,15 @@ check_root() {
     fi
 }
 
+# Function to use sudo only if available (relavant when sudo is unavailable, like in docker)
+run_sudo() {
+    if command -v sudo >/dev/null 2>&1; then
+        sudo "$@"
+    else
+        "$@"
+    fi
+}
+
 # Function to update sources for Ubuntu 24.04 or newer
 update_sources_ubuntu24() {
     local newMirror="$1"
@@ -341,7 +350,7 @@ update_sources_ubuntu24() {
         for sourcefile in /etc/apt/sources.list.d/ubuntu.sources; do
             if [ -f "$sourcefile" ]; then
                 # Update URIs line in the ubuntu.sources file
-                sudo sed -i "/^URIs:/ s|https\?://[^ ]*|$newMirror|g" "$sourcefile" || {
+                    run_sudo sed -i "/^URIs:/ s|https\?://[^ ]*|$newMirror|g" "$sourcefile" || {
                     echo "Error: Failed to update $sourcefile"
                     exit 1
                 }
@@ -369,7 +378,7 @@ update_sources_legacy() {
         exit 1
     fi
     
-    sudo sed -i "s|deb [a-z]*://[^ ]* |deb ${newMirror} |g" /etc/apt/sources.list || {
+    run_sudo sed -i "s|deb [a-z]*://[^ ]* |deb ${newMirror} |g" /etc/apt/sources.list || {
         echo "Error: Failed to update /etc/apt/sources.list"
         exit 1
     }
@@ -450,7 +459,7 @@ select_mirror() {
     fi
 
     echo "Testing new mirror speed with apt update..."
-    sudo rm -rf /var/lib/apt/lists/* && sudo apt update || {
+    run_sudo rm -rf /var/lib/apt/lists/* && run_sudo apt update || {
         echo "Error: Failed to update apt packages with the new mirror."
         exit 1
     }


### PR DESCRIPTION
In ubuntu docker images like `ubuntu:24.04` sudo is generally not available, This changes the script to only use sudo if available.,